### PR TITLE
Optimize TCP Message Passing

### DIFF
--- a/src/NexusMods.ProxyConsole/ClientRendererAdaptor.cs
+++ b/src/NexusMods.ProxyConsole/ClientRendererAdaptor.cs
@@ -53,11 +53,9 @@ public class ClientRendererAdaptor
                 {
                     case Render renderable:
                         await _renderer.RenderAsync(renderable.Renderable);
-                        await _serializer.AcknowledgeAsync();
                         break;
                     case Clear:
                         await _renderer.ClearAsync();
-                        await _serializer.AcknowledgeAsync();
                         break;
                     case ProgramArgumentsRequest:
                         await _serializer.SendAsync(new ProgramArgumentsResponse()

--- a/src/NexusMods.ProxyConsole/ProxiedRenderer.cs
+++ b/src/NexusMods.ProxyConsole/ProxiedRenderer.cs
@@ -42,7 +42,7 @@ public class ProxiedRenderer : IRenderer
     /// <param name="renderable"></param>
     public async ValueTask RenderAsync(IRenderable renderable)
     {
-        await _serializer.SendAndAckAsync(new Render {Renderable = renderable});
+        await _serializer.SendAsync(new Render {Renderable = renderable});
     }
 
     /// <summary>
@@ -50,6 +50,6 @@ public class ProxiedRenderer : IRenderer
     /// </summary>
     public async ValueTask ClearAsync()
     {
-        await _serializer.SendAndAckAsync(new Clear());
+        await _serializer.SendAsync(new Clear());
     }
 }

--- a/src/NexusMods.ProxyConsole/Serializer.cs
+++ b/src/NexusMods.ProxyConsole/Serializer.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using JetBrains.Annotations;
 using MemoryPack;
 using MemoryPack.Formatters;
 using MemoryPack.Streaming;
@@ -47,16 +48,14 @@ public class Serializer
 
             MemoryPackFormatterProvider.Register(new DynamicUnionFormatter<IRenderable>(listDefs.ToArray()));
         }
-
-
     }
-
 
     /// <summary>
     /// Sends the given message to the server and waits for an acknowledgement.
     /// </summary>
     /// <param name="msg"></param>
     /// <typeparam name="TMessage"></typeparam>
+    [PublicAPI]
     public async Task SendAndAckAsync<TMessage>(TMessage msg)
     where TMessage : IMessage
     {
@@ -94,6 +93,7 @@ public class Serializer
     /// <summary>
     /// Sends an acknowledgement to the server.
     /// </summary>
+    [PublicAPI]
     public Task AcknowledgeAsync()
     {
         return SendAsync(new Acknowledge());

--- a/src/NexusMods.SingleProcess/ClientProcessDirector.cs
+++ b/src/NexusMods.SingleProcess/ClientProcessDirector.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Net;
 using System.Net.Sockets;
@@ -37,6 +37,7 @@ public class ClientProcessDirector(ILogger<ClientProcessDirector> logger, Single
         logger.LogInformation("Found main process {ProcessId} listening on port {Port}", process.Id, port);
 
         _client = new TcpClient();
+        _client.NoDelay = true; // Disable Nagle's algorithm to reduce delay.
         try
         {
             await _client.ConnectAsync(IPAddress.Loopback, port);

--- a/src/NexusMods.SingleProcess/MainProcessDirector.cs
+++ b/src/NexusMods.SingleProcess/MainProcessDirector.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Net;
@@ -161,7 +161,7 @@ public class MainProcessDirector : ADirector
                 var combined = CancellationTokenSource.CreateLinkedTokenSource(_cancellationToken, timeout.Token);
 
                 var found = await _tcpListener!.AcceptTcpClientAsync(combined.Token);
-
+                found.NoDelay = true; // Disable Nagle's algorithm to reduce delay.
                 _runningClients.Add(Task.Run(() => HandleClientAsync(found, handler), _cancellationToken));
 
                 _logger.LogInformation("Accepted TCP connection from {RemoteEndPoint}",


### PR DESCRIPTION
Small patch set to optimize for message passing:

- Disable Nagle's Algorithm [Main Cause of the Issue]
- Disable Acknowledge on render messages.

Speeds up printing from around 10s to <0.1 seconds (too small to measure) on my machine.

For more details (and justification), read: 
- https://github.com/Nexus-Mods/NexusMods.SingleProcessApp/issues/9

Before:

https://github.com/Nexus-Mods/NexusMods.SingleProcessApp/assets/6697380/b0ca48ac-9e80-4961-9e74-10e581d40a06

After:

https://github.com/Nexus-Mods/NexusMods.SingleProcessApp/assets/6697380/740ee18f-e684-4060-a7d5-9c0c9cc3ea0c