### PR TITLE
Fixed: Incorrect Index in StartupDirector.Start

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,9 @@
 <Project>
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <IsPackable>false</IsPackable>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,7 +1,6 @@
 <Project>
     <PropertyGroup>
         <Nullable>enable</Nullable>
-        <LangVersion>11</LangVersion>
         <ImplicitUsings>false</ImplicitUsings>
         <WarningsAsErrors>Nullable</WarningsAsErrors>
     </PropertyGroup>

--- a/src/NexusMods.ProxyConsole.Abstractions/NexusMods.ProxyConsole.Abstractions.csproj
+++ b/src/NexusMods.ProxyConsole.Abstractions/NexusMods.ProxyConsole.Abstractions.csproj
@@ -1,9 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
+      <LangVersion>latest</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/NexusMods.ProxyConsole/NexusMods.ProxyConsole.csproj
+++ b/src/NexusMods.ProxyConsole/NexusMods.ProxyConsole.csproj
@@ -1,11 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
-    </PropertyGroup>
-
     <ItemGroup>
       <PackageReference Include="MemoryPack" Version="1.10.0" />
       <PackageReference Include="MemoryPack.Streaming" Version="1.10.0" />

--- a/src/NexusMods.SingleProcess/NexusMods.SingleProcess.csproj
+++ b/src/NexusMods.SingleProcess/NexusMods.SingleProcess.csproj
@@ -2,6 +2,7 @@
     <PropertyGroup>
       <RootNamespace>NexusMods.SingleProcess</RootNamespace>
       <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+      <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
       <PackageReference Include="MemoryPack.Streaming" Version="1.10.0" />

--- a/src/NexusMods.SingleProcess/StartupDirector.cs
+++ b/src/NexusMods.SingleProcess/StartupDirector.cs
@@ -57,7 +57,7 @@ public class StartupDirector
             {
                 return await _handler.StartUiWindowAsync();
             }
-            else if (args[1] == _handler.MainProcessArgument)
+            else if (args[0] == _handler.MainProcessArgument)
             {
                 return await StartMainProcessDirector();
             }

--- a/tests/NexusMods.SingleProcess.TestApp/NexusMods.SingleProcess.TestApp.csproj
+++ b/tests/NexusMods.SingleProcess.TestApp/NexusMods.SingleProcess.TestApp.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <GenerateProgramFile>false</GenerateProgramFile>
+        <LangVersion>latest</LangVersion>
 
     </PropertyGroup>
 

--- a/tests/NexusMods.SingleProcess.Tests/NexusMods.SingleProcess.Tests.csproj
+++ b/tests/NexusMods.SingleProcess.Tests/NexusMods.SingleProcess.Tests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <XunitStartupAssembly>NexusMods.SingleProcess.Tests</XunitStartupAssembly>
+        <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
       <ProjectReference Include="..\..\src\NexusMods.SingleProcess\NexusMods.SingleProcess.csproj" />


### PR DESCRIPTION
The debug path in `StartupDirector` is trying to access the MainProcess arg via an incorrect index.
This was fixed to make it match up with the non-debug code.

And I also fixed test builds in CI, just cause.